### PR TITLE
Persist image filename changes only after editing completes

### DIFF
--- a/src/app/image-converter/components/image-card-list.tsx
+++ b/src/app/image-converter/components/image-card-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import {
   FileDownIcon,
@@ -56,6 +56,13 @@ const ImageFilenameEditor: React.FC<{
 }> = ({ filename, setFilename }) => {
   const ref = useRef<HTMLFormElement>(null);
   const [editing, setEditing] = useState<boolean>(false);
+  const [draftFilename, setDraftFilename] = useState(filename);
+
+  useEffect(() => {
+    if (!editing) {
+      setDraftFilename(filename);
+    }
+  }, [editing, filename]);
 
   const handleSubmit = (event: React.SubmitEvent | React.FocusEvent) => {
     event.preventDefault();
@@ -64,7 +71,7 @@ const ImageFilenameEditor: React.FC<{
     const formData = new FormData(form);
     // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     const newFilename = formData.get('filename') as string | null;
-    if (newFilename) {
+    if (newFilename && newFilename !== filename) {
       setFilename(newFilename);
     }
     setEditing(false);
@@ -80,6 +87,7 @@ const ImageFilenameEditor: React.FC<{
         )}
         type='button'
         onClick={() => {
+          setDraftFilename(filename);
           setEditing(true);
         }}
       >
@@ -98,9 +106,9 @@ const ImageFilenameEditor: React.FC<{
       <Input
         name='filename'
         className='h-8 w-full flex-grow text-sm'
-        value={filename}
+        value={draftFilename}
         onChange={(event) => {
-          setFilename(event.target.value);
+          setDraftFilename(event.target.value);
         }}
         autoFocus
       />


### PR DESCRIPTION
### Motivation
- Prevent the managed image from being updated on every keystroke when a user edits the image filename to avoid excessive persistence/IO and flicker.
- Improve UX by only committing the new filename once the user finishes editing (submit/blur) and avoid unnecessary updates when the value hasn't changed.

### Description
- Added a local `draftFilename` state and imported `useEffect` in `src/app/image-converter/components/image-card-list.tsx` to host in-progress edits instead of mutating the managed image on each keystroke.
- Synchronized the draft with external `filename` changes when not editing via a `useEffect` dependency on `editing` and `filename`.
- Persisted the filename only on submit/blur in `handleSubmit`, and only if `newFilename !== filename`, and initialized `draftFilename` when entering edit mode.
- Bound the `Input` to `draftFilename` and update `draftFilename` on `onChange` instead of calling `setFilename` directly.

### Testing
- Ran linters/formatters successfully with `pnpm exec eslint --fix src/app/image-converter/components/image-card-list.tsx` and `pnpm exec prettier --write src/app/image-converter/components/image-card-list.tsx`.
- Ran unit tests with `pnpm test` and all unit tests passed (`62` tests passed).
- Installed Playwright browsers and system deps with `pnpm exec playwright install` and `pnpm exec playwright install-deps` and then ran e2e tests with `pnpm test:e2e`, and all e2e tests passed (`42` tests passed).
- Pre-commit initially failed due to `gitleaks` binary download; resolved by installing system `gitleaks` and seeding the scanner cache, then verified `pnpm exec gitleaks-secret-scanner --no-banner` succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac940ccb58832085d7b916adff3224)